### PR TITLE
Hide secrets in build logs + others

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# https://github.com/github/gitignore/blob/master/Maven.gitignore
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+
+# Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
+!/.mvn/wrapper/maven-wrapper.jar

--- a/README.md
+++ b/README.md
@@ -30,14 +30,12 @@ In each build job that will use the plugin, configure the following in the **Azu
 ```groovy
 node {
     def secrets = [
-        [ $class: 'AzureKeyVaultSecret', _secretType: 'Certificate', _name: 'MyCert00', _version: '', _envVariable: 'AzureKeyVault' ]
+        [ $class: 'AzureKeyVaultSecret', secretType: 'Certificate', name: 'MyCert00', version: '', envVariable: 'AzureKeyVault' ]
     ]
 
     wrap([$class: 'AzureKeyVaultBuildWrapper',
         azureKeyVaultSecrets: secrets,
         keyVaultURLOverride: 'https://mykeyvault.vault.azure.net',
-        applicationIDOverride: '',
-        applicationSecretOverride: null,
         credentialIDOverride: 'SPN_KEY_VAULT'
     ]) {
         sh 'echo $AzureKeyVault'

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,8 @@
     <jenkins.version>1.642.1</jenkins.version>
     <java.level>7</java.level>
     <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
+    <azure-credentials.version>1.5.0</azure-credentials.version>
+    <azure-commons.version>0.2.4</azure-commons.version>
   </properties>
 
   <name>Azure Key Vault Plugin</name>
@@ -87,7 +89,17 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>plain-credentials</artifactId>
-      <version>1.3</version>
+      <version>1.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>azure-credentials</artifactId>
+      <version>${azure-credentials.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>azure-commons-core</artifactId>
+      <version>${azure-commons.version}</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,13 +9,12 @@
     <version>2.11</version>
     <relativePath/>
   </parent>
-  <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>azure-keyvault</artifactId>
   <version>0.9.4</version>
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>1.625.3</jenkins.version>
+    <jenkins.version>1.642.1</jenkins.version>
     <java.level>7</java.level>
     <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
   </properties>

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultBuildWrapper.java
@@ -24,13 +24,12 @@
  
 package org.jenkinsci.plugins.azurekeyvaultplugin;
 
-import com.microsoft.azure.credentials.*;
 import com.microsoft.azure.keyvault.KeyVaultClient;
-import com.microsoft.azure.keyvault.authentication.KeyVaultCredentials;
 import com.microsoft.azure.keyvault.models.SecretBundle;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.IdCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import hudson.*;
 import hudson.model.*;
@@ -41,11 +40,8 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.QueryParameter;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.security.cert.Certificate;
@@ -136,7 +132,7 @@ public class AzureKeyVaultBuildWrapper extends SimpleBuildWrapper {
     
     // Get the default value only if it is not overridden for this build
     public String getKeyVaultURL() {
-        if (!AzureKeyVaultUtil.isNullOrEmpty(keyVaultURL)) {
+        if (StringUtils.isNotEmpty(keyVaultURL)) {
             return keyVaultURL;
         }
         return this.getDescriptor().getKeyVaultURL();
@@ -169,13 +165,13 @@ public class AzureKeyVaultBuildWrapper extends SimpleBuildWrapper {
         throws CredentialNotFoundException, CredentialException
     {
         // Try Credential
-        if (!AzureKeyVaultUtil.isNullOrEmpty(_credentialID))
+        if (StringUtils.isNotEmpty(_credentialID))
         {
-            LOGGER.log(Level.INFO, String.format("Fetching credentials by ID"));
+            LOGGER.log(Level.INFO, "Fetching credentials by ID");
             AzureKeyVaultCredential credential = getCredentialById(_credentialID, build);
             if (!credential.isApplicationIDValid())
             {
-                LOGGER.log(Level.INFO, String.format("Credential is password-only. Setting the username"));
+                LOGGER.log(Level.INFO, "Credential is password-only. Setting the username");
                 // Credential only contains the app secret - add the app id
                 credential.setApplicationID(getApplicationID());
             }
@@ -183,7 +179,7 @@ public class AzureKeyVaultBuildWrapper extends SimpleBuildWrapper {
         }
         
         // Try AppID/Secret
-        if (!AzureKeyVaultUtil.isNullOrEmpty(_applicationSecret))
+        if (AzureKeyVaultUtil.isNotEmpty(_applicationSecret))
         {
             LOGGER.log(Level.WARNING, String.format("Using explicit application secret. This will be deprecated in 1.0. Use Credential ID instead."));
             return new AzureKeyVaultCredential(getApplicationID(), _applicationSecret);
@@ -193,7 +189,7 @@ public class AzureKeyVaultBuildWrapper extends SimpleBuildWrapper {
     }
        
     public String getApplicationID() {
-        if (!AzureKeyVaultUtil.isNullOrEmpty(applicationID))
+        if (StringUtils.isNotEmpty(applicationID))
         {
             LOGGER.log(Level.INFO, String.format("Using override Application ID"));
             return applicationID;

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultBuildWrapper.java
@@ -274,7 +274,11 @@ public class AzureKeyVaultBuildWrapper extends SimpleBuildWrapper {
     }
         
     public void setUp(Context context, Run<?, ?> build, FilePath workspace,
-      Launcher launcher, TaskListener listener, EnvVars initialEnvironment) {           
+      Launcher launcher, TaskListener listener, EnvVars initialEnvironment) {
+        if (azureKeyVaultSecrets == null || azureKeyVaultSecrets.isEmpty()) {
+            return;
+        }
+
         AzureKeyVaultCredential creds;
         try {
             creds = getKeyVaultCredential(build);

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultBuildWrapper.java
@@ -122,8 +122,8 @@ public class AzureKeyVaultBuildWrapper extends SimpleBuildWrapper {
     }
     
     @DataBoundSetter
-    public void setApplicationSecretOverride(Secret applicationSecret) {
-        this.applicationSecret = applicationSecret;
+    public void setApplicationSecretOverride(String applicationSecret) {
+        this.applicationSecret = Secret.fromString(applicationSecret);
     }
     
     // Override Application Secret ID

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultBuildWrapper.java
@@ -297,6 +297,8 @@ public class AzureKeyVaultBuildWrapper extends SimpleBuildWrapper {
                 if (bundle != null) {
                     valuesToMask.add(bundle.value());
                     context.env(secret.getEnvVariable(), bundle.value());
+                } else {
+                    throw new AzureKeyVaultException(String.format("Secret: %s not found", secret.getName()));
                 }
             } else if (secret.isCertificate()) {
                 // Get Certificate from Keyvault as a Secret

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultBuildWrapper.java
@@ -31,6 +31,7 @@ import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.microsoft.azure.keyvault.KeyVaultClient;
 import com.microsoft.azure.keyvault.models.SecretBundle;
+import com.microsoft.azure.util.AzureCredentials;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -235,9 +236,20 @@ public class AzureKeyVaultBuildWrapper extends SimpleBuildWrapper {
             credential.setApplicationSecret(StandardUsernamePasswordCredentials.class.cast(cred).getPassword());
             return credential;
         }
+        else if (AzureCredentials.class.isInstance(cred)) {
+            LOGGER.log(Level.INFO, String.format("Fetched %s as AzureCredentials", credentialID));
+            CredentialsProvider.track(build, cred);
+            AzureCredentials azureCredentials = (AzureCredentials) cred;
+
+            credential.setApplicationID(azureCredentials.getClientId());
+            credential.setApplicationSecret(azureCredentials.getPlainClientSecret());
+            return credential;
+        }
         else
         {
-            throw new CredentialException("Could not determine the type for Secret id " + credentialID + " only 'Secret Text' and 'Username/Password' are supported");
+            throw new CredentialException("Could not determine the type for Secret id "
+                    + credentialID +
+                    " only 'Secret Text', 'Username/Password', and 'Microsoft Azure Service Principal' are supported");
         }
     }
     

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultCredential.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultCredential.java
@@ -28,12 +28,16 @@
 
 package org.jenkinsci.plugins.azurekeyvaultplugin;
 
-import com.microsoft.aad.adal4j.*;
+import com.microsoft.aad.adal4j.AuthenticationContext;
+import com.microsoft.aad.adal4j.AuthenticationResult;
+import com.microsoft.aad.adal4j.ClientCredential;
 import com.microsoft.azure.keyvault.authentication.KeyVaultCredentials;
+import hudson.util.Secret;
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import hudson.util.Secret;
 
 public class AzureKeyVaultCredential extends KeyVaultCredentials
 {
@@ -68,12 +72,12 @@ public class AzureKeyVaultCredential extends KeyVaultCredentials
     
     public boolean isApplicationIDValid()
     {
-        return !AzureKeyVaultUtil.isNullOrEmpty(applicationID);
+        return !StringUtils.isEmpty(applicationID);
     }
     
     public boolean isApplicationSecretValid()
     {
-        return !AzureKeyVaultUtil.isNullOrEmpty(applicationSecret);
+        return AzureKeyVaultUtil.isNotEmpty(applicationSecret);
     }
     
     public boolean isValid()

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultCredential.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultCredential.java
@@ -35,6 +35,7 @@ import com.microsoft.azure.keyvault.authentication.KeyVaultCredentials;
 import hudson.util.Secret;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -87,7 +88,8 @@ public class AzureKeyVaultCredential extends KeyVaultCredentials
 
     @Override
     public String doAuthenticate(String authorization, String resource, String scope) {
-        AuthenticationResult token = getAccessTokenFromClientCredentials(authorization, resource, applicationID, applicationSecret.toString());
+        Objects.requireNonNull(applicationSecret, "Application secret is a required value");
+        AuthenticationResult token = getAccessTokenFromClientCredentials(authorization, resource, applicationID, applicationSecret.getPlainText());
         return token.getAccessToken();
     }
 

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultException.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultException.java
@@ -1,0 +1,12 @@
+package org.jenkinsci.plugins.azurekeyvaultplugin;
+
+public class AzureKeyVaultException extends RuntimeException {
+
+    public AzureKeyVaultException(String message) {
+        super(message);
+    }
+
+    public AzureKeyVaultException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultSecret.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultSecret.java
@@ -21,18 +21,18 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
- 
+
 package org.jenkinsci.plugins.azurekeyvaultplugin;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
 
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.util.ListBoxModel;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
-public class AzureKeyVaultSecret extends 
-    AbstractDescribableImpl<AzureKeyVaultSecret>
+public class AzureKeyVaultSecret extends
+        AbstractDescribableImpl<AzureKeyVaultSecret>
 {
     public static final String typeSecret = "Secret";
     public static final String typeCertificate = "Certificate";
@@ -40,66 +40,70 @@ public class AzureKeyVaultSecret extends
     private String name;
     private String version;
     private String envVariable;
-    
+
     @DataBoundConstructor
-    public AzureKeyVaultSecret(String _secretType, String _name,
-        String _version, String _envVariable) {
-        secretType = _secretType;
-        envVariable = _envVariable;
-        name = _name;
-        version = _version;
+    public AzureKeyVaultSecret(
+            String secretType,
+            String name,
+            String version,
+            String envVariable
+    ) {
+        this.secretType = secretType;
+        this.name = name;
+        this.version = version;
+        this.envVariable = envVariable;
     }
-    
+
     public String getSecretType() {
         return secretType;
     }
-    
+
     @DataBoundSetter
-    public void setSecretType(String _secretType) {
-        secretType = _secretType;
+    public void setSecretType(String secretType) {
+        this.secretType = secretType;
     }
-        
+
     public String getName(){
         return name;
     }
-    
+
     @DataBoundSetter
-    public void setName(String _name) {
-        name = _name;
+    public void setName(String name) {
+        this.name = name;
     }
-    
+
     public String getVersion() {
         return version;
     }
-    
+
     @DataBoundSetter
-    public void setVersion(String _version) {
-        version = _version;
+    public void setVersion(String version) {
+        this.version = version;
     }
-    
+
     public String getEnvVariable() {
         return envVariable;
     }
-    
+
     @DataBoundSetter
-    public void setEnvVariable(String _envVariable) {
-        envVariable = _envVariable;
+    public void setEnvVariable(String envVariable) {
+        this.envVariable = envVariable;
     }
-    
+
     public boolean isPassword() {
         if (secretType == null || !secretType.equals(typeSecret)) {
             return false;
         }
         return true;
     }
-    
+
     public boolean isCertificate() {
         if (secretType == null || !secretType.equals(typeCertificate)) {
             return false;
         }
         return true;
     }
-    
+
     @Extension
     public static final class DescriptorImpl extends Descriptor<AzureKeyVaultSecret> {
         @Override
@@ -107,7 +111,7 @@ public class AzureKeyVaultSecret extends
         {
             return "Secret type, environment variable, and name/version pair for an Azure Key Vault secret";
         }
-        
+
         public ListBoxModel doFillSecretTypeItems() {
             ListBoxModel items = new ListBoxModel();
             items.add(typeSecret, typeSecret);

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultUtil.java
@@ -28,13 +28,8 @@ import hudson.util.Secret;
 
 public class AzureKeyVaultUtil
 {
-    public static boolean isNullOrEmpty(String s)
+    public static boolean isNotEmpty(Secret s)
     {
-        return s == null || s.isEmpty();
-    }
-    
-    public static boolean isNullOrEmpty(Secret s)
-    {
-        return s == null || s.toString().isEmpty();
+        return s == null || s.getPlainText().isEmpty();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultUtil.java
@@ -28,8 +28,8 @@ import hudson.util.Secret;
 
 public class AzureKeyVaultUtil
 {
-    public static boolean isNotEmpty(Secret s)
+    public static boolean isNotEmpty(Secret secret)
     {
-        return s == null || s.getPlainText().isEmpty();
+        return secret != null && !secret.getPlainText().isEmpty();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/MaskingConsoleLogFilter.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/MaskingConsoleLogFilter.java
@@ -1,0 +1,88 @@
+package org.jenkinsci.plugins.azurekeyvaultplugin;
+
+import hudson.console.ConsoleLogFilter;
+import hudson.console.LineTransformationOutputStream;
+import hudson.model.Run;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/*The logic in this class is borrowed from https://github.com/jenkinsci/credentials-binding-plugin/*/
+public class MaskingConsoleLogFilter extends ConsoleLogFilter
+        implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String charsetName;
+    private List<String> valuesToMask;
+
+
+    public MaskingConsoleLogFilter(final String charsetName,
+                                   List<String> valuesToMask) {
+        this.charsetName = charsetName;
+        this.valuesToMask = valuesToMask;
+    }
+
+    @Override
+    public OutputStream decorateLogger(Run run,
+                                       final OutputStream logger) {
+        return new LineTransformationOutputStream() {
+            Pattern p;
+
+            @Override
+            protected void eol(byte[] b, int len) throws IOException {
+                p = Pattern.compile(getPatternStringForSecrets(valuesToMask));
+                if (StringUtils.isBlank(p.pattern())){
+                    logger.write(b, 0, len);
+                    return;
+                }
+                Matcher m = p.matcher(new String(b, 0, len, charsetName));
+                if (m.find()) {
+                    logger.write(m.replaceAll("****").getBytes(charsetName));
+                } else {
+                    // Avoid byte → char → byte conversion unless we are actually doing something.
+                    logger.write(b, 0, len);
+                }
+            }
+        };
+    }
+
+    /**
+     * Utility method for turning a collection of secret strings into a single {@link String} for pattern compilation.
+     *
+     * @param secrets A collection of secret strings
+     * @return A {@link String} generated from that collection.
+     */
+    public static String getPatternStringForSecrets(Collection<String> secrets) {
+        if (secrets == null) return "";
+        StringBuilder b = new StringBuilder();
+        List<String> sortedByLength = new ArrayList<>(secrets.size());
+        for (String secret : secrets) {
+            if (secret != null) sortedByLength.add(secret);
+        }
+        Collections.sort(sortedByLength, new Comparator<String>() {
+            @Override
+            public int compare(String o1, String o2) {
+                return o2.length() - o1.length();
+            }
+        });
+
+        for (String secret : sortedByLength) {
+            if (b.length() > 0) {
+                b.append('|');
+            }
+            b.append(Pattern.quote(secret));
+        }
+        return b.toString();
+    }
+
+
+}

--- a/src/main/resources/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultBuildWrapper/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultBuildWrapper/config.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:c="/lib/credentials" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:section title="Azure Key Vault Plugin">
 
     <f:block>
@@ -10,11 +10,8 @@
         <f:entry title="Override Application ID" field="applicationIDOverride">
           <f:textbox />
         </f:entry>
-        <f:entry title="Override Application Secret" field="applicationSecretOverride">
-          <f:password />
-        </f:entry>
         <f:entry title="Override Credential ID" field="credentialIDOverride">
-          <f:textbox />
+          <c:select />
         </f:entry>
       </table>
     </f:block>

--- a/src/main/resources/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultBuildWrapper/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultBuildWrapper/global.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:c="/lib/credentials" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:section title="Azure Key Vault Plugin">
     <f:entry title="Key Vault URL" field="keyVaultURL">
       <f:textbox />
@@ -11,7 +11,7 @@
       <f:password />
     </f:entry>
     <f:entry title="Credential ID" field="credentialID">
-      <f:textbox />
+      <c:select />
     </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultBuildWrapper/help-credentialID.html
+++ b/src/main/resources/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultBuildWrapper/help-credentialID.html
@@ -1,5 +1,5 @@
 <div>Specify the Credential ID used for accessing KeyVault. 
 <ul>
  <li>If this credential is a <b>Secret Text</b> then it will supersede the Application Secret field</li>
- <li>If this credential is a <b>Username/Password</b> then it will supdersede the Application ID field AND the Application Secret Field</li>
+ <li>If this credential is a <b>Username/Password</b> or <b>Microsoft Azure Service Principal</b> then it will supersede the Application ID field AND the Application Secret Field</li>
 </ul></div>

--- a/src/main/resources/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultBuildWrapper/help-credentialIDOverride.html
+++ b/src/main/resources/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultBuildWrapper/help-credentialIDOverride.html
@@ -1,5 +1,5 @@
 <div>OPTIONAL: Overrides the Credential ID used for accessing KeyVault. 
 <ul>
  <li>If this credential is a <b>Secret Text</b> then it will override the Application Secret field</li>
- <li>If this credential is a <b>Username/Password</b> then it will override the Application ID field AND the Application Secret Field</li>
+ <li>If this credential is a <b>Username/Password</b> or <b>Microsoft Azure Service Principal</b> then it will supersede the Application ID field AND the Application Secret Field</li>
 </ul></div>


### PR DESCRIPTION
Features added:
* Hide secrets in build log
* Load credentials using a drop down in the UI instead of a text field where you had to put the ID
* Added support for the existing azure credentials plugin
* Add template git ignore
* Fail build if error during configuring, (This one was a big barrier for our developers when they first tried the plugin, it was returning null previously which hid all configuration errors)
* Removed _ from method parameters, I was getting configuration errors from the DSL and it wasn't a nice experience for users.
* Don't fail build when no secrets provided

Docs have been updated

Happy to split if this would help