### PR TITLE
Throw an error if no key vault url provided

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultBuildWrapper.java
@@ -141,7 +141,11 @@ public class AzureKeyVaultBuildWrapper extends SimpleBuildWrapper {
         if (StringUtils.isNotEmpty(keyVaultURL)) {
             return keyVaultURL;
         }
-        return this.getDescriptor().getKeyVaultURL();
+        if (StringUtils.isNotEmpty(this.getDescriptor().getKeyVaultURL())) {
+            return this.getDescriptor().getKeyVaultURL();
+        } else {
+            throw new AzureKeyVaultException("No key vault url configured, set one globally or in the build wrap step");
+        }
     }
 
     @Override


### PR DESCRIPTION
Previously it would go down to some rest interceptor eventually and hit:
`java.lang.IllegalArgumentException: Must provide a replacement value
for each pattern`